### PR TITLE
Fixed the cuda errors in 11_3_hello_rnn_gpu.py

### DIFF
--- a/11_3_hello_rnn_gpu.py
+++ b/11_3_hello_rnn_gpu.py
@@ -19,13 +19,14 @@ x_one_hot = [[[1, 0, 0, 0, 0],   # h 0
 
 y_data = [1, 0, 2, 3, 3, 4]    # ihello
 
-# As we have one batch of samples, we will change them to variables only once
-inputs = Variable(torch.Tensor(x_one_hot))
-labels = Variable(torch.LongTensor(y_data))
+def to_var(x):
+    if torch.cuda.is_available():
+        x = x.cuda()
+    return Variable(x)
 
-if torch.cuda.is_available():
-    inputs = inputs.cuda()
-    labels = labels.cuda()
+# As we have one batch of samples, we will change them to variables only once
+inputs = to_var(torch.Tensor(x_one_hot))
+labels = to_var(torch.LongTensor(y_data))
 
 num_classes = 5
 input_size = 5  # one-hot size
@@ -50,10 +51,8 @@ class RNN(nn.Module):
 
     def forward(self, x):
         # Initialize hidden and cell states
-        h_0 = Variable(torch.zeros(
+        h_0 = to_var(torch.zeros(
             x.size(0), self.num_layers, self.hidden_size))
-        if torch.cuda.is_available():
-            h_0 = h_0.cuda()
 
         # Reshape input
         x.view(x.size(0), self.sequence_length, self.input_size)

--- a/11_3_hello_rnn_gpu.py
+++ b/11_3_hello_rnn_gpu.py
@@ -24,8 +24,8 @@ inputs = Variable(torch.Tensor(x_one_hot))
 labels = Variable(torch.LongTensor(y_data))
 
 if torch.cuda.is_available():
-    inputs.cuda()
-    labels.cuda()
+    inputs = inputs.cuda()
+    labels = labels.cuda()
 
 num_classes = 5
 input_size = 5  # one-hot size
@@ -53,7 +53,7 @@ class RNN(nn.Module):
         h_0 = Variable(torch.zeros(
             x.size(0), self.num_layers, self.hidden_size))
         if torch.cuda.is_available():
-            h_0.cuda()
+            h_0 = h_0.cuda()
 
         # Reshape input
         x.view(x.size(0), self.sequence_length, self.input_size)
@@ -86,7 +86,7 @@ for epoch in range(100):
     loss.backward()
     optimizer.step()
     _, idx = outputs.max(1)
-    idx = idx.data.numpy()
+    idx = idx.data.cpu().numpy()
     result_str = [idx2char[c] for c in idx.squeeze()]
     print("epoch: %d, loss: %1.3f" % (epoch + 1, loss.data[0]))
     print("Predicted string: ", ''.join(result_str))


### PR DESCRIPTION
To convert a cpu tensor to a cuda tensor, you should use the assignment operator as shown below.

```python
# If model is an instance of nn.Module
model.cuda()   # this is okay (inplace operation)

# If x is a tensor
x.cuda()       # this is not okay (x is still a cpu tensor)
x = x.cuda()   # this is okay
```

In addition, `cuda()` creates a new node in the computational graph. It is recommended to convert the tensor to the cuda tensor first and wrap it with `Variable `as shown below. Please, see [here](https://discuss.pytorch.org/t/strange-behavior-of-variable-cuda-and-variable-grad/1642/5) for more information about this issue. Also, [here](https://discuss.pytorch.org/t/how-can-i-train-input-not-weight/2569/2).

```python
x = Variable(x.cuda())   # this is okay
x = Variable(x).cuda()   # this is not okay
```