### PR TITLE
fix: change the output method

### DIFF
--- a/05_linear_regression.py
+++ b/05_linear_regression.py
@@ -41,7 +41,7 @@ for epoch in range(500):
 
     # Compute and print loss
     loss = criterion(y_pred, y_data)
-    print(epoch, loss.data[0])
+    print(epoch, loss.item())
 
     # Zero gradients, perform a backward pass, and update the weights.
     optimizer.zero_grad()


### PR DESCRIPTION
`pytorch 1.0.0`에서 아래와 같이 에러가 발생해서 출력 메서드를 변경하였습니다.
```error
IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number
```