### PR TITLE
Debugging to run on new PyTorch version

### DIFF
--- a/12_2_hello_rnn.py
+++ b/12_2_hello_rnn.py
@@ -74,7 +74,7 @@ for epoch in range(100):
         hidden, output = model(hidden, input)
         val, idx = output.max(1)
         sys.stdout.write(idx2char[idx.data.item()])
-        loss += criterion(output, label)
+        loss += criterion(output, label.unsqueeze(0))
 
     print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss.data.item()))
 

--- a/12_2_hello_rnn.py
+++ b/12_2_hello_rnn.py
@@ -2,7 +2,6 @@
 import sys
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 
 torch.manual_seed(777)  # reproducibility
 #            0    1    2    3    4
@@ -20,8 +19,8 @@ y_data = [1, 0, 2, 3, 3, 4]    # ihello
 x_one_hot = [one_hot_lookup[x] for x in x_data]
 
 # As we have one batch of samples, we will change them to variables only once
-inputs = Variable(torch.Tensor(x_one_hot))
-labels = Variable(torch.LongTensor(y_data))
+inputs = torch.Tensor(x_one_hot)
+labels = torch.LongTensor(y_data)
 
 num_classes = 5
 input_size = 5  # one-hot size
@@ -51,7 +50,7 @@ class Model(nn.Module):
     def init_hidden(self):
         # Initialize hidden and cell states
         # (num_layers * num_directions, batch, hidden_size)
-        return Variable(torch.zeros(num_layers, batch_size, hidden_size))
+        return torch.zeros(num_layers, batch_size, hidden_size)
 
 
 # Instantiate RNN model

--- a/12_2_hello_rnn.py
+++ b/12_2_hello_rnn.py
@@ -73,10 +73,10 @@ for epoch in range(100):
         # print(input.size(), label.size())
         hidden, output = model(hidden, input)
         val, idx = output.max(1)
-        sys.stdout.write(idx2char[idx.data[0]])
+        sys.stdout.write(idx2char[idx.data.item()])
         loss += criterion(output, label)
 
-    print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss.data[0]))
+    print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss.data.item()))
 
     loss.backward()
     optimizer.step()


### PR DESCRIPTION
Changed all Tensors that were cast to Variables to just Tesnors, as those two classes are now merged. See docs [here](https://pytorch.org/blog/pytorch-0_4_0-migration-guide/#merging-tensor-and-variable-and-classes).

x.data[0] is degraded as well, so I changed those to x.data.item()

Finally, there is a dimension error that comes up when running this. The unsqueeze methods fixes this.

Tested on my system and the file runs with no errors or warnings.