### PR TITLE
Fix dimension errors in 12_2_hello_rnn.py

### DIFF
--- a/12_2_hello_rnn.py
+++ b/12_2_hello_rnn.py
@@ -75,9 +75,9 @@ for epoch in range(100):
         hidden, output = model(hidden, input)
         val, idx = output.max(1)
         sys.stdout.write(idx2char[idx.data[0]])
-        loss += criterion(output, label)
+        loss += criterion(output, torch.LongTensor([label]))
 
-    print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss.data[0]))
+    print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss))
 
     loss.backward()
     optimizer.step()


### PR DESCRIPTION
OS: Ubuntu 18.04
torch: 1.4.0

I got the following error when I ran 12_2_hello_rnn.py:


	Traceback (most recent call last):
	  File "12_2_hello_rnn.py", line 78, in <module>
		loss += criterion(output, label)
	  File "/home/adi/anaconda3/envs/pytorch_dev/lib/python3.6/site-packages/torch/nn/modules/module.py", line 532, in __call__
		result = self.forward(*input, **kwargs)
	  File "/home/adi/anaconda3/envs/pytorch_dev/lib/python3.6/site-packages/torch/nn/modules/loss.py", line 916, in forward
		ignore_index=self.ignore_index, reduction=self.reduction)
	  File "/home/adi/anaconda3/envs/pytorch_dev/lib/python3.6/site-packages/torch/nn/functional.py", line 2021, in cross_entropy
		return nll_loss(log_softmax(input, 1), target, weight, None, ignore_index, None, reduction)
	  File "/home/adi/anaconda3/envs/pytorch_dev/lib/python3.6/site-packages/torch/nn/functional.py", line 1834, in nll_loss
		if input.size(0) != target.size(0):
	IndexError: dimension specified as 0 but tensor has no dimensions

I'm guessing the "label" that is being passed while computing the loss is causing the error, since it has 0 dimensions. 
`
loss += criterion(output, label)
`

Which is why I converted it into a 1D LongTensor in the PR.
`
loss += criterion(output, torch.LongTensor([label]))
`

Another issue popped up after resolving this error:

	File "12_2_hello_rnn.py", line 80, in <module>
		print(", epoch: %d, loss: %1.3f" % (epoch + 1, loss.data[0]))
	IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number

Which i resolved by printing the loss directly since it has 0 dimensions (you may use loss.item() as well). The resulting script trained successfully, and the following was the output:

	Model(
	  (rnn): RNN(5, 5, batch_first=True)
	)
	predicted string: llllll, epoch: 1, loss: 10.155
	predicted string: llllll, epoch: 2, loss: 9.137
	predicted string: llllll, epoch: 3, loss: 8.355
	predicted string: llllll, epoch: 4, loss: 7.577
	predicted string: llllll, epoch: 5, loss: 6.876
	predicted string: lhelll, epoch: 6, loss: 6.327
	predicted string: ihelll, epoch: 7, loss: 6.014
	predicted string: ihelll, epoch: 8, loss: 5.787
	predicted string: ihelll, epoch: 9, loss: 5.477
	predicted string: ihelll, epoch: 10, loss: 5.274
	predicted string: ihelll, epoch: 11, loss: 5.041
	predicted string: ihello, epoch: 12, loss: 4.827
	predicted string: ihello, epoch: 13, loss: 4.676
	predicted string: ihello, epoch: 14, loss: 4.550
	predicted string: ihello, epoch: 15, loss: 4.430
	predicted string: ihello, epoch: 16, loss: 4.305
	predicted string: ihello, epoch: 17, loss: 4.164
	predicted string: ihelll, epoch: 18, loss: 4.003
	predicted string: ihelll, epoch: 19, loss: 3.860
	predicted string: ihelll, epoch: 20, loss: 3.879
	predicted string: ihelll, epoch: 21, loss: 3.768
	predicted string: ihelll, epoch: 22, loss: 3.642
	predicted string: ihelll, epoch: 23, loss: 3.599
	predicted string: ihello, epoch: 24, loss: 3.577
	predicted string: ihello, epoch: 25, loss: 3.544
	predicted string: ihello, epoch: 26, loss: 3.498
	predicted string: ihello, epoch: 27, loss: 3.439
	predicted string: ihello, epoch: 28, loss: 3.371
	predicted string: ihello, epoch: 29, loss: 3.303
	predicted string: ihello, epoch: 30, loss: 3.240
	predicted string: ihello, epoch: 31, loss: 3.162
	predicted string: ihello, epoch: 32, loss: 3.147
	predicted string: ihello, epoch: 33, loss: 3.178
	predicted string: ihello, epoch: 34, loss: 3.116
	predicted string: ihello, epoch: 35, loss: 3.042
	predicted string: ihello, epoch: 36, loss: 3.020
	predicted string: ihello, epoch: 37, loss: 3.015
	predicted string: ihello, epoch: 38, loss: 2.998
	predicted string: ihello, epoch: 39, loss: 2.977
	predicted string: ihello, epoch: 40, loss: 2.966
	predicted string: ihello, epoch: 41, loss: 2.961
	predicted string: ihello, epoch: 42, loss: 2.950
	predicted string: ihello, epoch: 43, loss: 2.930
	predicted string: ihello, epoch: 44, loss: 2.904
	predicted string: ihello, epoch: 45, loss: 2.888
	predicted string: ihello, epoch: 46, loss: 2.888
	predicted string: ihello, epoch: 47, loss: 2.879
	predicted string: ihello, epoch: 48, loss: 2.860
	predicted string: ihello, epoch: 49, loss: 2.857
	predicted string: ihello, epoch: 50, loss: 2.859
	predicted string: ihello, epoch: 51, loss: 2.852
	predicted string: ihello, epoch: 52, loss: 2.840
	predicted string: ihello, epoch: 53, loss: 2.834
	predicted string: ihello, epoch: 54, loss: 2.834
	predicted string: ihello, epoch: 55, loss: 2.824
	predicted string: ihello, epoch: 56, loss: 2.817
	predicted string: ihello, epoch: 57, loss: 2.817
	predicted string: ihello, epoch: 58, loss: 2.814
	predicted string: ihello, epoch: 59, loss: 2.808
	predicted string: ihello, epoch: 60, loss: 2.805
	predicted string: ihello, epoch: 61, loss: 2.805
	predicted string: ihello, epoch: 62, loss: 2.801
	predicted string: ihello, epoch: 63, loss: 2.796
	predicted string: ihello, epoch: 64, loss: 2.795
	predicted string: ihello, epoch: 65, loss: 2.793
	predicted string: ihello, epoch: 66, loss: 2.789
	predicted string: ihello, epoch: 67, loss: 2.786
	predicted string: ihello, epoch: 68, loss: 2.786
	predicted string: ihello, epoch: 69, loss: 2.783
	predicted string: ihello, epoch: 70, loss: 2.780
	predicted string: ihello, epoch: 71, loss: 2.780
	predicted string: ihello, epoch: 72, loss: 2.778
	predicted string: ihello, epoch: 73, loss: 2.776
	predicted string: ihello, epoch: 74, loss: 2.775
	predicted string: ihello, epoch: 75, loss: 2.774
	predicted string: ihello, epoch: 76, loss: 2.772
	predicted string: ihello, epoch: 77, loss: 2.770
	predicted string: ihello, epoch: 78, loss: 2.769
	predicted string: ihello, epoch: 79, loss: 2.768
	predicted string: ihello, epoch: 80, loss: 2.766
	predicted string: ihello, epoch: 81, loss: 2.765
	predicted string: ihello, epoch: 82, loss: 2.764
	predicted string: ihello, epoch: 83, loss: 2.763
	predicted string: ihello, epoch: 84, loss: 2.762
	predicted string: ihello, epoch: 85, loss: 2.761
	predicted string: ihello, epoch: 86, loss: 2.759
	predicted string: ihello, epoch: 87, loss: 2.759
	predicted string: ihello, epoch: 88, loss: 2.758
	predicted string: ihello, epoch: 89, loss: 2.757
	predicted string: ihello, epoch: 90, loss: 2.756
	predicted string: ihello, epoch: 91, loss: 2.755
	predicted string: ihello, epoch: 92, loss: 2.754
	predicted string: ihello, epoch: 93, loss: 2.753
	predicted string: ihello, epoch: 94, loss: 2.752
	predicted string: ihello, epoch: 95, loss: 2.751
	predicted string: ihello, epoch: 96, loss: 2.750
	predicted string: ihello, epoch: 97, loss: 2.750
	predicted string: ihello, epoch: 98, loss: 2.749
	predicted string: ihello, epoch: 99, loss: 2.748
	predicted string: ihello, epoch: 100, loss: 2.747
	Learning finished!