### PR TITLE
Lec11 bug fixed

### DIFF
--- a/11_1_toy_inception_mnist.py
+++ b/11_1_toy_inception_mnist.py
@@ -104,7 +104,7 @@ def train(epoch):
         if batch_idx % 10 == 0:
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),
-                100. * batch_idx / len(train_loader), loss.data[0]))
+                100. * batch_idx / len(train_loader), loss.data.item()))
 
 
 def test():
@@ -115,7 +115,7 @@ def test():
         data, target = Variable(data, volatile=True), Variable(target)
         output = model(data)
         # sum up batch loss
-        test_loss += F.nll_loss(output, target, size_average=False).data[0]
+        test_loss += F.nll_loss(output, target, size_average=False).item()
         # get the index of the max log-probability
         pred = output.data.max(1, keepdim=True)[1]
         correct += pred.eq(target.data.view_as(pred)).cpu().sum()


### PR DESCRIPTION
I found some error

> IndexError: invalid index of a 0-dim tensor. Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number

Then I changed,

In train function,

```python
loss.data.item() # loss.data[0] -> loss.data.item()
```

In test function,
```python
test_loss += F.nll_loss(output, target, size_average=False).item() # .data[0] -> .item()
```

It works well

